### PR TITLE
v1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "The minimum code coverage that is required to pass for changed files"
     required: false
     default: "80"
+  debug-mode:
+    description: "Run the action in debug mode and get debug logs printed in console"
+    required: false
+    default: "false"
 
 outputs:
   coverage-overall:
@@ -27,5 +31,5 @@ runs:
   main: "dist/index.js"
 
 branding:
-  icon: 'percent'
-  color: 'green'
+  icon: "percent"
+  color: "green"

--- a/dist/index.js
+++ b/dist/index.js
@@ -12426,7 +12426,7 @@ async function action() {
 }
 
 function debug(obj) {
-    JSON.stringify(obj, " ", 4)
+    return JSON.stringify(obj, " ", 4)
 }
 
 async function getJsonReport(xmlPath) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12407,7 +12407,7 @@ async function action() {
         if (debugMode) core.info(`changedFiles: ${debug(changedFiles)}`);
 
         const value = await reportJsonAsync;
-        if (debugMode) core.info(`report: ${debug(report)}`);
+        if (debugMode) core.info(`report value: ${debug(value)}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);

--- a/dist/index.js
+++ b/dist/index.js
@@ -12404,17 +12404,17 @@ async function action() {
         if (debugMode) core.info(`reportPath: ${reportPath}`);
         const reportJsonAsync = getJsonReport(reportPath);
         const changedFiles = await getChangedFiles(base, head, client);
-        if (debugMode) core.info(`changedFiles: ${changedFiles}`);
+        if (debugMode) core.info(`changedFiles: ${debug(changedFiles)}`);
 
         const value = await reportJsonAsync;
-        if (debugMode) core.info(`report: ${value}`);
+        if (debugMode) core.info(`report: ${debug(report)}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);
         if (debugMode) core.info(`overallCoverage: ${overallCoverage}`);
         core.setOutput("coverage-overall", parseFloat(overallCoverage.toFixed(2)));
         const filesCoverage = process.getFileCoverage(report, changedFiles);
-        if (debugMode) core.info(`filesCoverage: ${filesCoverage}`);
+        if (debugMode) core.info(`filesCoverage: ${debug(filesCoverage)}`);
         core.setOutput("coverage-changed-files", parseFloat(filesCoverage.percentage.toFixed(2)));
 
         if (prNumber != null) {
@@ -12423,6 +12423,10 @@ async function action() {
     } catch (error) {
         core.setFailed(error);
     }
+}
+
+function debug(obj) {
+    JSON.stringify(obj, " ", 4)
 }
 
 async function getJsonReport(xmlPath) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12365,6 +12365,7 @@ const core = __nccwpck_require__(4934);
 const github = __nccwpck_require__(6794);
 const fs = __nccwpck_require__(5747);
 const parser = __nccwpck_require__(1532);
+const { parseBooleans } = __nccwpck_require__(2526);
 const process = __nccwpck_require__(6332);
 const render = __nccwpck_require__(8279);
 
@@ -12373,6 +12374,7 @@ async function action() {
         const reportPath = core.getInput('path');
         const minCoverageOverall = parseFloat(core.getInput('min-coverage-overall'));
         const minCoverageChangedFiles = parseFloat(core.getInput('min-coverage-changed-files'));
+        const debugMode = parseBooleans(core.getInput('debug-mode'));
         const event = github.context.eventName;
         core.info(`Event is ${event}`);
 
@@ -12399,15 +12401,20 @@ async function action() {
 
         const client = github.getOctokit(core.getInput("token"));
 
+        if (debugMode) core.info(`reportPath: ${reportPath}`);
         const reportJsonAsync = getJsonReport(reportPath);
         const changedFiles = await getChangedFiles(base, head, client);
+        if (debugMode) core.info(`changedFiles: ${changedFiles}`);
 
         const value = await reportJsonAsync;
+        if (debugMode) core.info(`report: ${value}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);
+        if (debugMode) core.info(`overallCoverage: ${overallCoverage}`);
         core.setOutput("coverage-overall", parseFloat(overallCoverage.toFixed(2)));
         const filesCoverage = process.getFileCoverage(report, changedFiles);
+        if (debugMode) core.info(`filesCoverage: ${filesCoverage}`);
         core.setOutput("coverage-changed-files", parseFloat(filesCoverage.percentage.toFixed(2)));
 
         if (prNumber != null) {
@@ -12500,6 +12507,8 @@ function getFileCoverage(report, files) {
     result.files = resultFiles;
     if (resultFiles.length != 0) {
         result.percentage = getTotalPercentage(resultFiles);
+    } else {
+        result.percentage = 100;
     }
     return result;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -12498,12 +12498,14 @@ function getFileCoverage(report, files) {
             if (file != null) {
                 const fileName = sourceFile["$"].name;
                 const counters = sourceFile["counter"];
-                const coverage = getDetailedCoverage(counters, "INSTRUCTION");
-                file["name"] = fileName;
-                file["missed"] = coverage.missed;
-                file["covered"] = coverage.covered;
-                file["percentage"] = coverage.percentage;
-                resultFiles.push(file);
+                if (counters != null && counters.length != 0) {
+                    const coverage = getDetailedCoverage(counters, "INSTRUCTION");
+                    file["name"] = fileName;
+                    file["missed"] = coverage.missed;
+                    file["covered"] = coverage.covered;
+                    file["percentage"] = coverage.percentage;
+                    resultFiles.push(file);
+                }
             }
         });
         resultFiles.sort((a, b) => b.percentage - a.percentage)

--- a/src/action.js
+++ b/src/action.js
@@ -63,7 +63,7 @@ async function action() {
 }
 
 function debug(obj) {
-    JSON.stringify(obj, " ", 4)
+    return JSON.stringify(obj, " ", 4)
 }
 
 async function getJsonReport(xmlPath) {

--- a/src/action.js
+++ b/src/action.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const fs = require('fs');
 const parser = require('xml2js');
+const { parseBooleans } = require('xml2js/lib/processors');
 const process = require('./process');
 const render = require('./render');
 
@@ -10,6 +11,7 @@ async function action() {
         const reportPath = core.getInput('path');
         const minCoverageOverall = parseFloat(core.getInput('min-coverage-overall'));
         const minCoverageChangedFiles = parseFloat(core.getInput('min-coverage-changed-files'));
+        const debugMode = parseBooleans(core.getInput('debug-mode'));
         const event = github.context.eventName;
         core.info(`Event is ${event}`);
 
@@ -36,15 +38,20 @@ async function action() {
 
         const client = github.getOctokit(core.getInput("token"));
 
+        if (debugMode) core.info(`reportPath: ${reportPath}`);
         const reportJsonAsync = getJsonReport(reportPath);
         const changedFiles = await getChangedFiles(base, head, client);
+        if (debugMode) core.info(`changedFiles: ${changedFiles}`);
 
         const value = await reportJsonAsync;
+        if (debugMode) core.info(`report: ${value}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);
+        if (debugMode) core.info(`overallCoverage: ${overallCoverage}`);
         core.setOutput("coverage-overall", parseFloat(overallCoverage.toFixed(2)));
         const filesCoverage = process.getFileCoverage(report, changedFiles);
+        if (debugMode) core.info(`filesCoverage: ${filesCoverage}`);
         core.setOutput("coverage-changed-files", parseFloat(filesCoverage.percentage.toFixed(2)));
 
         if (prNumber != null) {

--- a/src/action.js
+++ b/src/action.js
@@ -41,17 +41,17 @@ async function action() {
         if (debugMode) core.info(`reportPath: ${reportPath}`);
         const reportJsonAsync = getJsonReport(reportPath);
         const changedFiles = await getChangedFiles(base, head, client);
-        if (debugMode) core.info(`changedFiles: ${changedFiles}`);
+        if (debugMode) core.info(`changedFiles: ${debug(changedFiles)}`);
 
         const value = await reportJsonAsync;
-        if (debugMode) core.info(`report: ${value}`);
+        if (debugMode) core.info(`report: ${debug(report)}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);
         if (debugMode) core.info(`overallCoverage: ${overallCoverage}`);
         core.setOutput("coverage-overall", parseFloat(overallCoverage.toFixed(2)));
         const filesCoverage = process.getFileCoverage(report, changedFiles);
-        if (debugMode) core.info(`filesCoverage: ${filesCoverage}`);
+        if (debugMode) core.info(`filesCoverage: ${debug(filesCoverage)}`);
         core.setOutput("coverage-changed-files", parseFloat(filesCoverage.percentage.toFixed(2)));
 
         if (prNumber != null) {
@@ -60,6 +60,10 @@ async function action() {
     } catch (error) {
         core.setFailed(error);
     }
+}
+
+function debug(obj) {
+    JSON.stringify(obj, " ", 4)
 }
 
 async function getJsonReport(xmlPath) {

--- a/src/action.js
+++ b/src/action.js
@@ -44,7 +44,7 @@ async function action() {
         if (debugMode) core.info(`changedFiles: ${debug(changedFiles)}`);
 
         const value = await reportJsonAsync;
-        if (debugMode) core.info(`report: ${debug(report)}`);
+        if (debugMode) core.info(`report value: ${debug(value)}`);
         const report = value["report"];
 
         const overallCoverage = process.getOverallCoverage(report);

--- a/src/process.js
+++ b/src/process.js
@@ -26,6 +26,8 @@ function getFileCoverage(report, files) {
     result.files = resultFiles;
     if (resultFiles.length != 0) {
         result.percentage = getTotalPercentage(resultFiles);
+    } else {
+        result.percentage = 100;
     }
     return result;
 }

--- a/src/process.js
+++ b/src/process.js
@@ -13,12 +13,14 @@ function getFileCoverage(report, files) {
             if (file != null) {
                 const fileName = sourceFile["$"].name;
                 const counters = sourceFile["counter"];
-                const coverage = getDetailedCoverage(counters, "INSTRUCTION");
-                file["name"] = fileName;
-                file["missed"] = coverage.missed;
-                file["covered"] = coverage.covered;
-                file["percentage"] = coverage.percentage;
-                resultFiles.push(file);
+                if (counters != null && counters.length != 0) {
+                    const coverage = getDetailedCoverage(counters, "INSTRUCTION");
+                    file["name"] = fileName;
+                    file["missed"] = coverage.missed;
+                    file["covered"] = coverage.covered;
+                    file["percentage"] = coverage.percentage;
+                    resultFiles.push(file);
+                }
             }
         });
         resultFiles.sort((a, b) => b.percentage - a.percentage)


### PR DESCRIPTION
The sourceFile for an Interface doesn't have a `counters` array. This was causing issues when the project has an interface. Fixed it now. Interfaced won't participate in code coverage.