### PR TITLE
Support pull request target

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
         id: jacoco
         uses: madrapps/jacoco-report@v1.2
         with:
-          path: ${{ github.workspace }}/build/reports/jacoco/testCoverage/testCoverage.xml
+          paths: ${{ github.workspace }}/build/reports/jacoco/testCoverage/testCoverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/__tests__/action_single.test.js
+++ b/__tests__/action_single.test.js
@@ -106,6 +106,35 @@ describe("Single report", function () {
     });
   });
 
+  describe("Pull Request Target event", function () {
+    const context = {
+      eventName: "pull_request_target",
+      payload: {
+        pull_request: {
+          number: "45",
+          base: {
+            sha: "guasft7asdtf78asfd87as6df7y2u3",
+          },
+          head: {
+            sha: "aahsdflais76dfa78wrglghjkaghkj",
+          },
+        },
+      },
+      repo: "jacoco-playground",
+      owner: "madrapps",
+    };
+
+    it("set overall coverage output", async () => {
+      github.context = context;
+      core.setOutput = output;
+
+      await action.action();
+
+      const out = output.mock.calls[0];
+      expect(out).toEqual(["coverage-overall", 49.02]);
+    });
+  })
+
   describe("Push event", function () {
     const context = {
       eventName: "push",
@@ -138,7 +167,7 @@ describe("Single report", function () {
     });
   });
 
-  describe("Other than push or pull_request event", function () {
+  describe("Other than push or pull_request or pull_request_target event", function () {
     const context = {
       eventName: "pr_review",
     };

--- a/src/action.js
+++ b/src/action.js
@@ -26,6 +26,7 @@ async function action() {
     var prNumber;
     switch (event) {
       case "pull_request":
+      case "pull_request_target":
         base = github.context.payload.pull_request.base.sha;
         head = github.context.payload.pull_request.head.sha;
         prNumber = github.context.payload.pull_request.number;


### PR DESCRIPTION
Adding new PR against 1.3 - follows: https://github.com/Madrapps/jacoco-report/pull/6

pull_request_target allows you to run GHA across forks - which is insecure for public repositories but useful for enterprise or private repos.

This PR adds support for this GHA event.

I'm not entirely sure how to verify that this event supports the same payload as pull_request