### PR TITLE
Add an option to update comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   title:
     description: "Optional title for the Pull Request comment"
     required: false
+  update-comment:
+    description: "Update the coverage report comment instead of creating new ones. Requires title to works properly."
+    required: false
+    default: "false"
   debug-mode:
     description: "Run the action in debug mode and get debug logs printed in console"
     required: false

--- a/src/action.js
+++ b/src/action.js
@@ -17,6 +17,7 @@ async function action() {
       core.getInput("min-coverage-changed-files")
     );
     const title = core.getInput("title");
+    const updateComment = parseBooleans(core.getInput("update-comment"));
     const debugMode = parseBooleans(core.getInput("debug-mode"));
     const event = github.context.eventName;
     core.info(`Event is ${event}`);
@@ -70,6 +71,8 @@ async function action() {
     if (prNumber != null) {
       await addComment(
         prNumber,
+        updateComment,
+        render.getTitle(title),
         render.getPRComment(
           overallCoverage.project,
           filesCoverage,
@@ -117,12 +120,35 @@ async function getChangedFiles(base, head, client) {
   return changedFiles;
 }
 
-async function addComment(prNumber, comment, client) {
-  await client.issues.createComment({
-    issue_number: prNumber,
-    body: comment,
-    ...github.context.repo,
-  });
+async function addComment(prNumber, update, title, body, client) {
+  let commentUpdated = false;
+
+  if (update && title) {
+    const comments = await client.issues.listComments({
+      issue_number: prNumber,
+      ...github.context.repo,
+    });
+    const comment = comments.data.find((comment) =>
+      comment.body.startsWith(title),
+    );
+
+    if (comment) {
+      await client.issues.updateComment({
+        comment_id: comment.id,
+        body: body,
+        ...github.context.repo,
+      });
+      commentUpdated = true;
+    }
+  }
+
+  if (!commentUpdated) {
+    await client.issues.createComment({
+      issue_number: prNumber,
+      body: body,
+      ...github.context.repo,
+    });
+  }
 }
 
 module.exports = {

--- a/src/render.js
+++ b/src/render.js
@@ -75,4 +75,5 @@ function formatCoverage(coverage) {
 
 module.exports = {
   getPRComment,
+  getTitle,
 };


### PR DESCRIPTION
Adds an option to update the first comment posted by the action instead of posting a new one every time. The option is disabled by default to avoid breaking changes and requires a non-empty title.

Fixes #11