### PR TITLE
Upgrade action to use node20 to avoid warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ outputs:
     description: 'The total coverage of all changed files'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
node16 actions are deprecated; use `node20`