### PR TITLE
Use automatic github token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for [Creating a workflow file](https://help.github.com/en/articles/configuring-a
 ### Inputs
 
 - `paths` - [**required**] Comma separated paths of the generated jacoco xml files (supports wildcard glob pattern)
-- `token` - [**required**] Github personal token to add comments to Pull Request
+- `token` - Github token to add comments to Pull Request (defaults to automatic token, make sure job permissions allow it to write to pull_requests)
 - `min-coverage-overall` - [*optional* {default: 80%}] The minimum code coverage that is required to pass for overall project
 - `min-coverage-changed-files` - [*optional* {default: 80%}] The minimum code coverage that is required to pass for changed files
 - `update-comment` - [*optional* {default: false}] If true, updates the previous coverage report comment instead of creating new one.

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,9 @@ inputs:
     description: 'Comma separated paths of the generated jacoco xml files (supports wildcard glob pattern)'
     required: true
   token:
-    description: 'Github personal token to add comments to Pull Request'
-    required: true
+    description: Github token to add comments to Pull Request (defaults to automatic token, make sure job permissions allow it to write to pull_requests)
+    required: false
+    default: ${{ github.token }}
   min-coverage-overall:
     description: 'The minimum code coverage that is required to pass for overall project'
     required: false


### PR DESCRIPTION
Github allows actions to default to referencing the automatic github
token using `${{ github.token }}`. This can make it easier for shared
workflows and wrapping actions to avoid needing to explicitly pass
through a token unless required.
