### PR TITLE
Update README with required permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for [Creating a workflow file](https://help.github.com/en/articles/configuring-a
 
 Note: The following permissions are required for the action to run:
 - `issues: write` (or `pull-requests: write`)
-- `content: read`
+- `contents: read`
 
 ### Inputs
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ An [example workflow](#example-workflow) is available below. For more informatio
 Documentation
 for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
+Note: The following permissions are required for the action to run:
+- `issues: write` (or `pull-requests: write`)
+- `content: read`
+
 ### Inputs
 
 - `paths` - [**required**] Comma separated paths of the generated jacoco xml files (supports wildcard glob pattern)


### PR DESCRIPTION
Related to #24 

Hi!

I'm using this action in my own repo, and at first it failed due to insufficient permissions.

This PR updates the README so it clarifies the list of permissions that the action needs.

The logs report as follows:

```
Run madrapps/jacoco-report@v1.7.2
[...]
Error: HttpError: Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

Following the github documentation, writing comments in an issue needs either `issues: write` or `pull-requests: write` permissions.

Thank you for your work :)